### PR TITLE
Updated prefabs to follow new pattern that colliders require a rigid body

### DIFF
--- a/Gems/ArchVis/Assets/Props/Bar_Drop_Ceiling_Lights_B071F6VV2T/bar_drop_ceiling_lights.prefab
+++ b/Gems/ArchVis/Assets/Props/Bar_Drop_Ceiling_Lights_B071F6VV2T/bar_drop_ceiling_lights.prefab
@@ -73,7 +73,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{0151AD2E-440B-5C26-B11A-3D171A382FC1}"
-                                            }
+                                            },
+                                            "assetHint": "props/bar_drop_ceiling_lights_b071f6vv2t/bar_drop_ceiling_lights_dropceilinglightsmat.azmaterial"
                                         }
                                     }
                                 },
@@ -177,6 +178,10 @@
                 "Component_[6330147308401542046]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 6330147308401542046
+                },
+                "Component_[6615173953912049307]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6615173953912049307
                 },
                 "Component_[9573904982155412668]": {
                     "$type": "AZ::Render::EditorMeshComponent",

--- a/Gems/ArchVis/Assets/Props/Bar_Stool_B075YPTF9H/bar_stool.prefab
+++ b/Gems/ArchVis/Assets/Props/Bar_Stool_B075YPTF9H/bar_stool.prefab
@@ -88,6 +88,10 @@
                         }
                     }
                 },
+                "Component_[10106196129130127297]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10106196129130127297
+                },
                 "Component_[10536287574423402570]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10536287574423402570,
@@ -160,7 +164,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{6B0C634A-93A6-5CC2-AFE1-536E33B70835}"
-                                            }
+                                            },
+                                            "assetHint": "props/bar_stool_b075yptf9h/bar_stool_bar_stoolmat.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/ArchVis/Assets/Props/Bedroom_Night_Stand_B07374SBFM/bedroom_night_stand.prefab
+++ b/Gems/ArchVis/Assets/Props/Bedroom_Night_Stand_B07374SBFM/bedroom_night_stand.prefab
@@ -23,10 +23,6 @@
                 "$type": "EditorVisibilityComponent",
                 "Id": 15590610628451104250
             },
-            "Component_[2294281114027282688]": {
-                "$type": "SelectionComponent",
-                "Id": 2294281114027282688
-            },
             "Component_[288231474581574358]": {
                 "$type": "EditorOnlyEntityComponent",
                 "Id": 288231474581574358
@@ -118,10 +114,6 @@
                         ]
                     }
                 },
-                "Component_[16602977417737851804]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16602977417737851804
-                },
                 "Component_[17775225480107915307]": {
                     "$type": "EditorColliderComponent",
                     "Id": 17775225480107915307,
@@ -190,6 +182,10 @@
                 "Component_[8992506460531177955]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8992506460531177955
+                },
+                "Component_[9488254759555241958]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9488254759555241958
                 },
                 "Component_[9808233233817054274]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Gems/ArchVis/Assets/Props/Cabinet_B07HSDP2CP/cabinet.prefab
+++ b/Gems/ArchVis/Assets/Props/Cabinet_B07HSDP2CP/cabinet.prefab
@@ -51,6 +51,10 @@
             "Id": "Entity_[3224488473310]",
             "Name": "cabinet",
             "Components": {
+                "Component_[10180045359570889654]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10180045359570889654
+                },
                 "Component_[11331045626929712376]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11331045626929712376
@@ -90,7 +94,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{E28F6129-B21E-5397-A4FA-4532BB6CEF31}"
-                                            }
+                                            },
+                                            "assetHint": "props/cabinet_b07hsdp2cp/cabinet_cabinetmat.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/ArchVis/Assets/Props/Chair_B082VM23MF/chair.prefab
+++ b/Gems/ArchVis/Assets/Props/Chair_B082VM23MF/chair.prefab
@@ -92,6 +92,10 @@
                         }
                     }
                 },
+                "Component_[13878199089475633525]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13878199089475633525
+                },
                 "Component_[14163871262101623436]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 14163871262101623436
@@ -189,7 +193,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{178EC5F9-F66D-5A23-BAE9-ACF9B6C9B16C}"
-                                            }
+                                            },
+                                            "assetHint": "props/chair_b082vm23mf/chair_pillowmat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Computer_Desk_B075ZBVZST/computer_desk.prefab
+++ b/Gems/ArchVis/Assets/Props/Computer_Desk_B075ZBVZST/computer_desk.prefab
@@ -120,7 +120,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{9AB497BE-8748-53DC-AE61-3BC92E87C3B0}"
-                                            }
+                                            },
+                                            "assetHint": "props/computer_desk_b075zbvzst/computer_desk_computerdeskmat.azmaterial"
                                         }
                                     }
                                 }
@@ -184,6 +185,10 @@
                 "Component_[6693361317612951287]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6693361317612951287
+                },
+                "Component_[8766200635734147512]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8766200635734147512
                 },
                 "Component_[9649747607656642026]": {
                     "$type": "EditorInspectorComponent",

--- a/Gems/ArchVis/Assets/Props/Decor_Bench_B082QD7WY8/decor_bench.prefab
+++ b/Gems/ArchVis/Assets/Props/Decor_Bench_B082QD7WY8/decor_bench.prefab
@@ -55,6 +55,10 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 12874252152937448070
                 },
+                "Component_[13905792950461768599]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13905792950461768599
+                },
                 "Component_[14376407054765774658]": {
                     "$type": "EditorColliderComponent",
                     "Id": 14376407054765774658,
@@ -64,11 +68,6 @@
                                 {
                                     "Name": "decorBenchMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -156,7 +155,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{2161B00F-FEE6-52FC-8E91-50FA1C8B8C3A}"
-                                            }
+                                            },
+                                            "assetHint": "props/decor_bench_b082qd7wy8/decor_bench_decorbenchmat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Dinner_Table_B075YP4WYT/dinner_table.prefab
+++ b/Gems/ArchVis/Assets/Props/Dinner_Table_B075YP4WYT/dinner_table.prefab
@@ -141,6 +141,10 @@
                         }
                     ]
                 },
+                "Component_[4259953522708371511]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4259953522708371511
+                },
                 "Component_[6842166626713226172]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 6842166626713226172
@@ -154,11 +158,6 @@
                                 {
                                     "Name": "dinnerTableMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Dinner_Table_Ceiling_Light/Dinner_Table_Ceiling_Light.prefab
+++ b/Gems/ArchVis/Assets/Props/Dinner_Table_Ceiling_Light/Dinner_Table_Ceiling_Light.prefab
@@ -43,10 +43,6 @@
             "Component_[7240026170358048154]": {
                 "$type": "EditorPendingCompositionComponent",
                 "Id": 7240026170358048154
-            },
-            "Component_[9487362017662405837]": {
-                "$type": "SelectionComponent",
-                "Id": 9487362017662405837
             }
         }
     },
@@ -58,10 +54,6 @@
                 "Component_[11304362432591287512]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11304362432591287512
-                },
-                "Component_[11429937988734995309]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11429937988734995309
                 },
                 "Component_[12378120647433380967]": {
                     "$type": "EditorLockComponent",
@@ -79,12 +71,6 @@
                                 {
                                     "Name": "ceilingLightGlassMAT_001"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
                             ]
                         }
                     },
@@ -157,6 +143,10 @@
                 "Component_[5329200380050422279]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 5329200380050422279
+                },
+                "Component_[6713553817898178369]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6713553817898178369
                 },
                 "Component_[8415030259949418618]": {
                     "$type": "EditorEntityIconComponent",

--- a/Gems/ArchVis/Assets/Props/Dinner_Table_Floor_Rug/dinner_table_floor_rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Dinner_Table_Floor_Rug/dinner_table_floor_rug.prefab
@@ -15,10 +15,6 @@
                 "$type": "EditorVisibilityComponent",
                 "Id": 13152789842858417183
             },
-            "Component_[14520866505816828900]": {
-                "$type": "SelectionComponent",
-                "Id": 14520866505816828900
-            },
             "Component_[14582704527588228858]": {
                 "$type": "EditorEntitySortComponent",
                 "Id": 14582704527588228858
@@ -63,6 +59,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 12009203558432691165
                 },
+                "Component_[1258031797052467739]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1258031797052467739
+                },
                 "Component_[12765071306608823372]": {
                     "$type": "EditorColliderComponent",
                     "Id": 12765071306608823372,
@@ -72,11 +72,6 @@
                                 {
                                     "Name": "rugMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -158,10 +153,6 @@
                 "Component_[6389097479235996113]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6389097479235996113
-                },
-                "Component_[6973899403870601776]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6973899403870601776
                 },
                 "Component_[8797326685111546333]": {
                     "$type": "EditorMaterialComponent",

--- a/Gems/ArchVis/Assets/Props/End_Table_B072ZLCB32/end_table.prefab
+++ b/Gems/ArchVis/Assets/Props/End_Table_B072ZLCB32/end_table.prefab
@@ -86,11 +86,6 @@
                                     "Name": "endtableMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -138,6 +133,10 @@
                         }
                     }
                 },
+                "Component_[4196544701062327498]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4196544701062327498
+                },
                 "Component_[4201802800257239453]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 4201802800257239453
@@ -169,7 +168,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{33BB593B-D558-5164-B274-51E420E771EA}"
-                                            }
+                                            },
+                                            "assetHint": "props/end_table_b072zlcb32/end_table_endtablemat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Floor_Rug_B0732L974X/rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Floor_Rug_B0732L974X/rug.prefab
@@ -77,11 +77,6 @@
                                     "Name": "rugMAT_001"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -120,7 +115,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{583B5C98-5128-5BA5-B871-1A248BF0AA3D}"
-                                            }
+                                            },
+                                            "assetHint": "props/floor_rug_b0732l974x/rug_rugmat.azmaterial"
                                         }
                                     }
                                 },
@@ -203,6 +199,10 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9287117124148162593,
                     "Parent Entity": "ContainerEntity"
+                },
+                "Component_[940667800826917274]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 940667800826917274
                 }
             }
         }

--- a/Gems/ArchVis/Assets/Props/Floor_Rug_B0735THVQH/rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Floor_Rug_B0735THVQH/rug.prefab
@@ -15,10 +15,6 @@
                 "$type": "EditorEntitySortComponent",
                 "Id": 15023731860986084199
             },
-            "Component_[16025035117791640615]": {
-                "$type": "SelectionComponent",
-                "Id": 16025035117791640615
-            },
             "Component_[16220559466892839875]": {
                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                 "Id": 16220559466892839875,
@@ -63,10 +59,6 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10934679314045245098,
                     "Parent Entity": "ContainerEntity"
-                },
-                "Component_[12130516708706482242]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12130516708706482242
                 },
                 "Component_[15109562205062192652]": {
                     "$type": "EditorMaterialComponent",
@@ -140,6 +132,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 6166736019872166217
                 },
+                "Component_[7978532872712211580]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7978532872712211580
+                },
                 "Component_[8348138537399918701]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 8348138537399918701,
@@ -166,11 +162,6 @@
                                 {
                                     "Name": "rugMAT_002"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Floor_Rug_B07B4YQGFJ/rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Floor_Rug_B07B4YQGFJ/rug.prefab
@@ -11,10 +11,6 @@
                 "$type": "EditorVisibilityComponent",
                 "Id": 10794882038643108898
             },
-            "Component_[12016565522832123242]": {
-                "$type": "SelectionComponent",
-                "Id": 12016565522832123242
-            },
             "Component_[13280587531227942251]": {
                 "$type": "EditorPrefabComponent",
                 "Id": 13280587531227942251
@@ -99,10 +95,6 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 11443286174533576208
                 },
-                "Component_[12334561147778566503]": {
-                    "$type": "SelectionComponent",
-                    "Id": 12334561147778566503
-                },
                 "Component_[13637080831142381891]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 13637080831142381891,
@@ -167,11 +159,6 @@
                                     "Name": "rugMAT_003"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -199,6 +186,10 @@
                 "Component_[8312713832917910975]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 8312713832917910975
+                },
+                "Component_[9992835306267862897]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9992835306267862897
                 }
             }
         }

--- a/Gems/ArchVis/Assets/Props/Kitchen_Cook_Book/kitchen_cookbook.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Cook_Book/kitchen_cookbook.prefab
@@ -73,7 +73,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{55C00D3F-D3A8-5762-B67F-E38AC821F3D7}"
-                                            }
+                                            },
+                                            "assetHint": "props/kitchen_cook_book/kitchen_cookbook_bookmat.azmaterial"
                                         }
                                     }
                                 },
@@ -106,6 +107,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[15999072418410280999]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15999072418410280999
                 },
                 "Component_[16658864357536151967]": {
                     "$type": "EditorVisibilityComponent",
@@ -156,12 +161,6 @@
                                 {
                                     "Name": "bookHolderMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Kitchen_Cutting_Boards/Kitchen_Cutting_Boards.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Cutting_Boards/Kitchen_Cutting_Boards.prefab
@@ -51,6 +51,10 @@
             "Id": "Entity_[2454197838553]",
             "Name": "kitchen_cutting_boards",
             "Components": {
+                "Component_[10536319061152035845]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10536319061152035845
+                },
                 "Component_[12072168030209706892]": {
                     "$type": "EditorLockComponent",
                     "Id": 12072168030209706892
@@ -80,11 +84,6 @@
                                 {
                                     "Name": "cuttingBoardsMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -180,7 +179,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{8F4ADE22-5888-552E-88F8-5AD2EBC2C7FB}"
-                                            }
+                                            },
+                                            "assetHint": "props/kitchen_cutting_boards/kitchen_cutting_boards_cuttingboardsmat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Kitchen_Knives/Kitchen_Knives.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Knives/Kitchen_Knives.prefab
@@ -110,11 +110,6 @@
                                     "Name": "kitchen_knivesMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -153,6 +148,10 @@
                             180.0
                         ]
                     }
+                },
+                "Component_[4959006165051949865]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4959006165051949865
                 },
                 "Component_[6792732792196094553]": {
                     "$type": "EditorEntitySortComponent",
@@ -193,7 +192,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{1F4CE8A1-A843-58AF-831E-59BB78A33D79}"
-                                            }
+                                            },
+                                            "assetHint": "props/kitchen_knives/kitchen_knives_kitchen_knivesmat.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/ArchVis/Assets/Props/Kitchen_Oven/kitchen_oven.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Oven/kitchen_oven.prefab
@@ -72,6 +72,10 @@
                         ]
                     }
                 },
+                "Component_[15188787950180202254]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15188787950180202254
+                },
                 "Component_[17282523455370069792]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 17282523455370069792,
@@ -146,11 +150,6 @@
                                 {
                                     "Name": "ovenMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Kitchen_Refrigerator_MOD000016/refrigerator.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Refrigerator_MOD000016/refrigerator.prefab
@@ -55,6 +55,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 10311596869287372686
                 },
+                "Component_[10713743556368181965]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10713743556368181965
+                },
                 "Component_[11755868307902649292]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 11755868307902649292
@@ -68,11 +72,6 @@
                                 {
                                     "Name": "refrigeratorMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -133,7 +132,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{1BC6D96C-54C8-5EE2-B442-9C6DEEAA1C51}"
-                                            }
+                                            },
+                                            "assetHint": "props/kitchen_refrigerator_mod000016/refrigerator_refrigeratormat.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/ArchVis/Assets/Props/Kitchen_Spice_Jars/kitchen_spice_jars.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Spice_Jars/kitchen_spice_jars.prefab
@@ -11,10 +11,6 @@
                 "$type": "EditorInspectorComponent",
                 "Id": 10464611571102767786
             },
-            "Component_[1417720326797745590]": {
-                "$type": "SelectionComponent",
-                "Id": 1417720326797745590
-            },
             "Component_[15840304665972375133]": {
                 "$type": "EditorOnlyEntityComponent",
                 "Id": 15840304665972375133
@@ -139,11 +135,6 @@
                                     "Name": "spice_jar_glassMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -175,10 +166,6 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 44472983014378288
                 },
-                "Component_[5052228686842122735]": {
-                    "$type": "SelectionComponent",
-                    "Id": 5052228686842122735
-                },
                 "Component_[5138225458320332650]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 5138225458320332650,
@@ -199,6 +186,10 @@
                 "Component_[6473387802420173736]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6473387802420173736
+                },
+                "Component_[695929284102766763]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 695929284102766763
                 },
                 "Component_[7746287939788490160]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/Gems/ArchVis/Assets/Props/Kitchen_Utensils/kitchen_utensils.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Utensils/kitchen_utensils.prefab
@@ -66,7 +66,8 @@
                                             "assetId": {
                                                 "guid": "{8A42B566-4777-5D92-802D-055684D1BDF7}",
                                                 "subId": 1893364996
-                                            }
+                                            },
+                                            "assetHint": "props/kitchen_utensils/kitchen_utensils_kitchen_utensilsmat_1276278812691821828.azmaterial"
                                         }
                                     }
                                 },
@@ -135,11 +136,6 @@
                                     "Name": "kitchen_utensilsMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -178,6 +174,10 @@
                 "Component_[5280932098969691028]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 5280932098969691028
+                },
+                "Component_[6298157567043015855]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6298157567043015855
                 },
                 "Component_[7020969489580153262]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Gems/ArchVis/Assets/Props/Media_Cabinet_B07QB8DQ45/media_cabinet.prefab
+++ b/Gems/ArchVis/Assets/Props/Media_Cabinet_B07QB8DQ45/media_cabinet.prefab
@@ -97,11 +97,6 @@
                                     "Name": "media_cabinetMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -147,7 +142,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{16278723-6BC2-5502-BCDF-E3FCFA0562D9}"
-                                            }
+                                            },
+                                            "assetHint": "props/media_cabinet_b07qb8dq45/media_cabinet_media_cabinetmat.azmaterial"
                                         }
                                     }
                                 },
@@ -188,6 +184,10 @@
                 "Component_[5649706384646617640]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 5649706384646617640
+                },
+                "Component_[5835036196815411784]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5835036196815411784
                 },
                 "Component_[8465921459584657643]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/Gems/ArchVis/Assets/Props/Night_Stand_Lamp_B07374SBFM/night_stand_lamp.prefab
+++ b/Gems/ArchVis/Assets/Props/Night_Stand_Lamp_B07374SBFM/night_stand_lamp.prefab
@@ -60,6 +60,10 @@
                     "Id": 12997255732548536103,
                     "Parent Entity": "ContainerEntity"
                 },
+                "Component_[13091482506817377708]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13091482506817377708
+                },
                 "Component_[16430823481975613736]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 16430823481975613736
@@ -77,11 +81,6 @@
                                 {
                                     "Name": "lampMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -165,7 +164,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{26460E51-3116-5DF0-AC53-364962DF0524}"
-                                            }
+                                            },
+                                            "assetHint": "props/night_stand_lamp_b07374sbfm/night_stand_lamp_lampmat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Office_Desk_Chair_B082BLFMRC/office_desk_chair.prefab
+++ b/Gems/ArchVis/Assets/Props/Office_Desk_Chair_B082BLFMRC/office_desk_chair.prefab
@@ -82,7 +82,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{A9D51900-DBD8-559C-BF1B-C07BB82D63F5}"
-                                            }
+                                            },
+                                            "assetHint": "props/office_desk_chair_b082blfmrc/office_desk_chair_chairmat.azmaterial"
                                         }
                                     }
                                 }
@@ -103,11 +104,6 @@
                                 {
                                     "Name": "chairMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -139,6 +135,10 @@
                 "Component_[1591285332999096147]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1591285332999096147
+                },
+                "Component_[1771834518608223425]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1771834518608223425
                 },
                 "Component_[17888621638593099422]": {
                     "$type": "EditorInspectorComponent",

--- a/Gems/ArchVis/Assets/Props/Office_Desk_Lamp_B07B4YHYQV/office_desk_lamp.prefab
+++ b/Gems/ArchVis/Assets/Props/Office_Desk_Lamp_B07B4YHYQV/office_desk_lamp.prefab
@@ -43,10 +43,6 @@
             "Component_[3269740662557966876]": {
                 "$type": "EditorEntitySortComponent",
                 "Id": 3269740662557966876
-            },
-            "Component_[3958584789697740590]": {
-                "$type": "SelectionComponent",
-                "Id": 3958584789697740590
             }
         }
     },
@@ -55,10 +51,6 @@
             "Id": "Entity_[4502897238745]",
             "Name": "office_desk_lamp",
             "Components": {
-                "Component_[10664357243121766607]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10664357243121766607
-                },
                 "Component_[11713920357012905635]": {
                     "$type": "EditorLockComponent",
                     "Id": 11713920357012905635
@@ -72,11 +64,6 @@
                                 {
                                     "Name": "office_desk_lampMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -143,6 +130,10 @@
                 "Component_[154064183945706649]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 154064183945706649
+                },
+                "Component_[16524935274981040661]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16524935274981040661
                 },
                 "Component_[18176744606315359627]": {
                     "$type": "EditorVisibilityComponent",

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_B075HR7LHQ/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_B075HR7LHQ/potted_plant.prefab
@@ -117,7 +117,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{CFF8429B-30BB-54F4-BFED-A4720B0D04E3}"
-                                            }
+                                            },
+                                            "assetHint": "props/potted_plant_b075hr7lhq/potted_plant_potmat.azmaterial"
                                         }
                                     }
                                 }
@@ -137,12 +138,6 @@
                                 {
                                     "Name": "plantMAT_002"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
                             ]
                         }
                     },
@@ -191,6 +186,10 @@
                 "Component_[154792677440616745]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 154792677440616745
+                },
+                "Component_[16748275356268628935]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16748275356268628935
                 },
                 "Component_[1837893883740410061]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000002/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000002/potted_plant.prefab
@@ -7,10 +7,6 @@
                 "$type": "EditorDisabledCompositionComponent",
                 "Id": 10979427400929351536
             },
-            "Component_[11209660427775607159]": {
-                "$type": "SelectionComponent",
-                "Id": 11209660427775607159
-            },
             "Component_[13005057565548713476]": {
                 "$type": "EditorPrefabComponent",
                 "Id": 13005057565548713476
@@ -96,6 +92,10 @@
                         ]
                     }
                 },
+                "Component_[11664106037724625920]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11664106037724625920
+                },
                 "Component_[12282705548812581643]": {
                     "$type": "EditorColliderComponent",
                     "Id": 12282705548812581643,
@@ -105,11 +105,6 @@
                                 {
                                     "Name": "potted_plantMAT_004"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -186,10 +181,6 @@
                 "Component_[386356404792294599]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 386356404792294599
-                },
-                "Component_[6105075385885721443]": {
-                    "$type": "SelectionComponent",
-                    "Id": 6105075385885721443
                 },
                 "Component_[7217294098657686218]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000045/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000045/potted_plant.prefab
@@ -78,7 +78,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{C2EC2223-D369-52BD-BD03-C9D529F6F692}"
-                                            }
+                                            },
+                                            "assetHint": "props/potted_plant_trbp000045/potted_plant_plantmat.azmaterial"
                                         }
                                     }
                                 }
@@ -131,6 +132,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 4469866794322698325
                 },
+                "Component_[4748929468013442416]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4748929468013442416
+                },
                 "Component_[5436624600400660822]": {
                     "$type": "EditorColliderComponent",
                     "Id": 5436624600400660822,
@@ -140,11 +145,6 @@
                                 {
                                     "Name": "plantMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000054/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000054/potted_plant.prefab
@@ -61,11 +61,6 @@
                                     "Name": "potted_plantMAT_005"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -113,6 +108,10 @@
                 "Component_[2077912948004812003]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 2077912948004812003
+                },
+                "Component_[2284980380660003684]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2284980380660003684
                 },
                 "Component_[3307653644081368326]": {
                     "$type": "EditorEntityIconComponent",
@@ -170,7 +169,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{A8ED22EE-FE7A-564F-9651-DCC3A0E27C6A}"
-                                            }
+                                            },
+                                            "assetHint": "props/potted_plant_trbp000054/potted_plant_potted_plantmat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Sectional_Sofa_B07QDL46GB/sectional_sofa.prefab
+++ b/Gems/ArchVis/Assets/Props/Sectional_Sofa_B07QDL46GB/sectional_sofa.prefab
@@ -58,6 +58,10 @@
             "Id": "Entity_[5752732721881]",
             "Name": "sectional_sofa",
             "Components": {
+                "Component_[10051246426520152592]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10051246426520152592
+                },
                 "Component_[13389172003601302059]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 13389172003601302059,
@@ -91,11 +95,6 @@
                                 {
                                     "Name": "sofaMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Single_Bed_Frame_B0856FL9HR/single_bed_frame.prefab
+++ b/Gems/ArchVis/Assets/Props/Single_Bed_Frame_B0856FL9HR/single_bed_frame.prefab
@@ -15,10 +15,6 @@
                 "$type": "EditorPrefabComponent",
                 "Id": 12032533301644267498
             },
-            "Component_[15805644616917366189]": {
-                "$type": "SelectionComponent",
-                "Id": 15805644616917366189
-            },
             "Component_[16072785689235445020]": {
                 "$type": "EditorVisibilityComponent",
                 "Id": 16072785689235445020
@@ -192,6 +188,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17335388245100114700
                 },
+                "Component_[17456989292439253776]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17456989292439253776
+                },
                 "Component_[18322450601296185927]": {
                     "$type": "EditorLockComponent",
                     "Id": 18322450601296185927
@@ -205,11 +205,6 @@
                                 {
                                     "Name": "FrameMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -237,10 +232,6 @@
                     "DebugDrawSettings": {
                         "LocallyEnabled": false
                     }
-                },
-                "Component_[9397677546824248316]": {
-                    "$type": "SelectionComponent",
-                    "Id": 9397677546824248316
                 }
             }
         }

--- a/Gems/ArchVis/Assets/Props/Stack_Books_B07374SBFM/stack_books.prefab
+++ b/Gems/ArchVis/Assets/Props/Stack_Books_B07374SBFM/stack_books.prefab
@@ -27,10 +27,6 @@
                 "$type": "EditorPendingCompositionComponent",
                 "Id": 18314678870241216374
             },
-            "Component_[4281563244182903438]": {
-                "$type": "SelectionComponent",
-                "Id": 4281563244182903438
-            },
             "Component_[4546372456443542475]": {
                 "$type": "EditorDisabledCompositionComponent",
                 "Id": 4546372456443542475
@@ -141,10 +137,6 @@
                         }
                     }
                 },
-                "Component_[14882696788945985260]": {
-                    "$type": "SelectionComponent",
-                    "Id": 14882696788945985260
-                },
                 "Component_[15831654428134972620]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 15831654428134972620,
@@ -178,12 +170,6 @@
                                 {
                                     "Name": "top_bookMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
                             ]
                         }
                     },
@@ -228,6 +214,10 @@
                 "Component_[4592309060407943885]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 4592309060407943885
+                },
+                "Component_[5843594090990233065]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5843594090990233065
                 },
                 "Component_[5946974796973869892]": {
                     "$type": "EditorEntitySortComponent",

--- a/Gems/ArchVis/Assets/Props/Stack_Magazines/Stack_Magazines.prefab
+++ b/Gems/ArchVis/Assets/Props/Stack_Magazines/Stack_Magazines.prefab
@@ -70,11 +70,6 @@
                                     "Name": "stack_magazinesMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -109,6 +104,10 @@
                 "Component_[13880585715419203883]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 13880585715419203883
+                },
+                "Component_[14867379314654596849]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14867379314654596849
                 },
                 "Component_[15426398110938833779]": {
                     "$type": "EditorInspectorComponent",
@@ -165,7 +164,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{EAFFC45C-0FF9-5959-BCCA-362AD0D7BF4E}"
-                                            }
+                                            },
+                                            "assetHint": "props/stack_magazines/stack_magazines_stack_magazinesmat.azmaterial"
                                         }
                                     }
                                 },

--- a/Gems/ArchVis/Assets/Props/Sunglasses_TRB000046/sunglasses.prefab
+++ b/Gems/ArchVis/Assets/Props/Sunglasses_TRB000046/sunglasses.prefab
@@ -65,7 +65,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{060BE268-0974-5735-A27E-FB66CBA782A3}"
-                                            }
+                                            },
+                                            "assetHint": "props/sunglasses_trb000046/sunglasses_framesmat.azmaterial"
                                         }
                                     }
                                 },
@@ -178,12 +179,6 @@
                                     "Name": "lensesMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -210,6 +205,10 @@
                     "DebugDrawSettings": {
                         "LocallyEnabled": false
                     }
+                },
+                "Component_[6726793250645456279]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6726793250645456279
                 },
                 "Component_[9469151848128424079]": {
                     "$type": "EditorLockComponent",

--- a/Gems/ArchVis/Assets/Props/TV_Audio_B082L6KJ2J/tv_audio.prefab
+++ b/Gems/ArchVis/Assets/Props/TV_Audio_B082L6KJ2J/tv_audio.prefab
@@ -12,10 +12,6 @@
                 "Id": 11653080833421791239,
                 "Parent Entity": ""
             },
-            "Component_[12288848220688374308]": {
-                "$type": "SelectionComponent",
-                "Id": 12288848220688374308
-            },
             "Component_[12739549340015439397]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 12739549340015439397
@@ -71,10 +67,6 @@
                         }
                     }
                 },
-                "Component_[13080418106997335760]": {
-                    "$type": "SelectionComponent",
-                    "Id": 13080418106997335760
-                },
                 "Component_[15707550101131808264]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15707550101131808264,
@@ -83,6 +75,10 @@
                 "Component_[1671190249418993828]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 1671190249418993828
+                },
+                "Component_[2329015732814802237]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2329015732814802237
                 },
                 "Component_[4626033346789649623]": {
                     "$type": "EditorEntitySortComponent",
@@ -184,14 +180,6 @@
                                 {
                                     "Name": "part3"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {},
-                                {},
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Table_Chair_B075Z8M22B/table_chair.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Chair_B075Z8M22B/table_chair.prefab
@@ -69,7 +69,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{4E17EC7C-4150-5066-A3C4-06D9541F2A21}"
-                                            }
+                                            },
+                                            "assetHint": "props/table_chair_b075z8m22b/table_chair_table_chairmat.azmaterial"
                                         }
                                     }
                                 },
@@ -103,11 +104,6 @@
                                 {
                                     "Name": "table_chairMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -164,6 +160,10 @@
                             "SortIndex": 2
                         }
                     ]
+                },
+                "Component_[5370941666256165996]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5370941666256165996
                 },
                 "Component_[5759902956707758743]": {
                     "$type": "EditorLockComponent",

--- a/Gems/ArchVis/Assets/Props/Table_Lamp_B07HKF28CS/table_lamp.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Lamp_B07HKF28CS/table_lamp.prefab
@@ -116,7 +116,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{4332F31F-35CA-5094-9D1F-CBC174BC3439}"
-                                            }
+                                            },
+                                            "assetHint": "props/table_lamp_b07hkf28cs/table_lamp_lampmat.azmaterial"
                                         }
                                     }
                                 },
@@ -165,6 +166,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 17420561946348862865
                 },
+                "Component_[1917170847737081571]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1917170847737081571
+                },
                 "Component_[3425607196026404363]": {
                     "$type": "EditorLockComponent",
                     "Id": 3425607196026404363
@@ -185,12 +190,6 @@
                                 {
                                     "Name": "lampMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000041/table_potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000041/table_potted_plant.prefab
@@ -63,6 +63,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 17835342368245165545
                 },
+                "Component_[2873557806594362596]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2873557806594362596
+                },
                 "Component_[3775759128618609658]": {
                     "$type": "EditorLockComponent",
                     "Id": 3775759128618609658
@@ -96,12 +100,6 @@
                                 {
                                     "Name": "plantMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
                             ]
                         }
                     },
@@ -224,7 +222,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{218A9522-FD2D-5591-9DC7-EC792CC04978}"
-                                            }
+                                            },
+                                            "assetHint": "props/table_potted_plant_trb000041/table_potted_plant_potmat.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000056/table_potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000056/table_potted_plant.prefab
@@ -102,7 +102,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{A46AE36D-211B-5068-BF3C-DA200D7DF7CA}"
-                                            }
+                                            },
+                                            "assetHint": "props/table_potted_plant_trb000056/table_potted_plant_potted_plantmat.azmaterial"
                                         }
                                     }
                                 },
@@ -132,11 +133,6 @@
                                 {
                                     "Name": "potted_plantMAT_001"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -173,6 +169,10 @@
                 "Component_[15391541167130683698]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 15391541167130683698
+                },
+                "Component_[15621530748404884313]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15621530748404884313
                 },
                 "Component_[16522800004863759594]": {
                     "$type": "EditorLockComponent",

--- a/Gems/ArchVis/Assets/Props/Wall_Art_Two_Set/wall_art_two_set.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Art_Two_Set/wall_art_two_set.prefab
@@ -15,10 +15,6 @@
                 "$type": "EditorPrefabComponent",
                 "Id": 14968683463742142930
             },
-            "Component_[15551291559397689467]": {
-                "$type": "SelectionComponent",
-                "Id": 15551291559397689467
-            },
             "Component_[1878525969651090249]": {
                 "$type": "EditorVisibilityComponent",
                 "Id": 1878525969651090249
@@ -116,12 +112,6 @@
                                     "Name": "picture_twoMAT"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -149,10 +139,6 @@
                 "Component_[15336089270810769994]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15336089270810769994
-                },
-                "Component_[17432003565821643530]": {
-                    "$type": "SelectionComponent",
-                    "Id": 17432003565821643530
                 },
                 "Component_[17722260920902550511]": {
                     "$type": "EditorInspectorComponent",
@@ -216,6 +202,10 @@
                         ],
                         "UniformScale": 10.0
                     }
+                },
+                "Component_[9384307394379592000]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9384307394379592000
                 }
             }
         }

--- a/Gems/ArchVis/Assets/Props/Wall_Clock/Wall_Clock.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Clock/Wall_Clock.prefab
@@ -75,6 +75,10 @@
                         }
                     }
                 },
+                "Component_[13222523447285762473]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13222523447285762473
+                },
                 "Component_[15919337670898642848]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 15919337670898642848
@@ -88,11 +92,6 @@
                                 {
                                     "Name": "wall_clockMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Wall_Painting/Wall_Painting.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Painting/Wall_Painting.prefab
@@ -35,10 +35,6 @@
                 "$type": "EditorEntityIconComponent",
                 "Id": 2241401585427710114
             },
-            "Component_[8980527089668936068]": {
-                "$type": "SelectionComponent",
-                "Id": 8980527089668936068
-            },
             "Component_[9105297834536471009]": {
                 "$type": "EditorPendingCompositionComponent",
                 "Id": 9105297834536471009
@@ -55,13 +51,13 @@
             "Id": "Entity_[1560915844862]",
             "Name": "wall_painting",
             "Components": {
-                "Component_[10260915273151729803]": {
-                    "$type": "SelectionComponent",
-                    "Id": 10260915273151729803
-                },
                 "Component_[11204479918377056313]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 11204479918377056313
+                },
+                "Component_[11835762462359242578]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11835762462359242578
                 },
                 "Component_[11885409761003560783]": {
                     "$type": "EditorColliderComponent",
@@ -72,11 +68,6 @@
                                 {
                                     "Name": "paintingMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Props/Wall_Painting_Collection_Three/wall_painting_collection_three.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Painting_Collection_Three/wall_painting_collection_three.prefab
@@ -35,10 +35,6 @@
                 "$type": "EditorLockComponent",
                 "Id": 3496759247179200902
             },
-            "Component_[3589674891434971325]": {
-                "$type": "SelectionComponent",
-                "Id": 3589674891434971325
-            },
             "Component_[6939696691164101596]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 6939696691164101596
@@ -62,6 +58,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 10126209226803571948
                 },
+                "Component_[10340462272711671343]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10340462272711671343
+                },
                 "Component_[10609676482643697315]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 10609676482643697315
@@ -81,10 +81,6 @@
                 "Component_[16351616525781740035]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 16351616525781740035
-                },
-                "Component_[16560977146164170288]": {
-                    "$type": "SelectionComponent",
-                    "Id": 16560977146164170288
                 },
                 "Component_[2247643189384880211]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/Gems/ArchVis/Assets/Props/Wall_Print/Wall_Print.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Print/Wall_Print.prefab
@@ -20,10 +20,6 @@
                 "$type": "EditorEntityIconComponent",
                 "Id": 1653800203982705790
             },
-            "Component_[18309446775872868976]": {
-                "$type": "SelectionComponent",
-                "Id": 18309446775872868976
-            },
             "Component_[240591650796720189]": {
                 "$type": "EditorLockComponent",
                 "Id": 240591650796720189
@@ -55,10 +51,6 @@
             "Id": "Entity_[1904513228542]",
             "Name": "wall_print",
             "Components": {
-                "Component_[1112310540582195634]": {
-                    "$type": "SelectionComponent",
-                    "Id": 1112310540582195634
-                },
                 "Component_[11292219814052442655]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 11292219814052442655,
@@ -84,6 +76,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 12011669299392151575
                 },
+                "Component_[13447601309243456577]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13447601309243456577
+                },
                 "Component_[15026422971092846704]": {
                     "$type": "EditorColliderComponent",
                     "Id": 15026422971092846704,
@@ -93,11 +89,6 @@
                                 {
                                     "Name": "wall_printMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },

--- a/Gems/ArchVis/Assets/Rooms/Interior_03/interior_03.prefab
+++ b/Gems/ArchVis/Assets/Rooms/Interior_03/interior_03.prefab
@@ -63,6 +63,10 @@
                     "Id": 12369918107656431496,
                     "Parent Entity": "ContainerEntity"
                 },
+                "Component_[13255577044041970141]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13255577044041970141
+                },
                 "Component_[1531729883950092994]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 1531729883950092994,
@@ -498,37 +502,6 @@
                                 {
                                     "Name": "Wood_FloorMAT"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {}
                             ]
                         }
                     },


### PR DESCRIPTION
**IMPORTANT: Please approve but DO NOT merge this PR yet!** 

@moraaar will merge it once the work in [PhysX_StaticRigidBody_Staging](https://github.com/aws-lumberyard-dev/o3de/tree/PhysX_StaticRigidBody_Staging) branch is in o3de/development.

More information about this update here: https://github.com/o3de/o3de/pull/14261

Steps done:
- Open Editor.
- Run command `ed_physxUpdatePrefabsWithColliderComponents`.

Signed-off-by: moraaar <moraaar@amazon.com>