### PR TITLE
Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Gems/ArchVis/Assets/Props/Bar_Drop_Ceiling_Lights_B071F6VV2T/bar_drop_ceiling_lights.prefab
+++ b/Gems/ArchVis/Assets/Props/Bar_Drop_Ceiling_Lights_B071F6VV2T/bar_drop_ceiling_lights.prefab
@@ -112,7 +112,7 @@
                     "Id": 1995021287546556989
                 },
                 "Component_[2710058381432013883]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2710058381432013883,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Bar_Stool_B075YPTF9H/bar_stool.prefab
+++ b/Gems/ArchVis/Assets/Props/Bar_Stool_B075YPTF9H/bar_stool.prefab
@@ -55,7 +55,7 @@
             "Name": "bar_stool",
             "Components": {
                 "Component_[10026616198511755833]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 10026616198511755833,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -194,7 +194,7 @@
                     }
                 },
                 "Component_[4611969092363961158]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4611969092363961158,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Bedroom_Night_Stand_B07374SBFM/bedroom_night_stand.prefab
+++ b/Gems/ArchVis/Assets/Props/Bedroom_Night_Stand_B07374SBFM/bedroom_night_stand.prefab
@@ -115,7 +115,7 @@
                     }
                 },
                 "Component_[17775225480107915307]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17775225480107915307,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Cabinet_B07HSDP2CP/cabinet.prefab
+++ b/Gems/ArchVis/Assets/Props/Cabinet_B07HSDP2CP/cabinet.prefab
@@ -108,7 +108,7 @@
                     "Id": 16685673422636032207
                 },
                 "Component_[16745041218502227783]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16745041218502227783,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Chair_B082VM23MF/chair.prefab
+++ b/Gems/ArchVis/Assets/Props/Chair_B082VM23MF/chair.prefab
@@ -101,7 +101,7 @@
                     "Id": 14163871262101623436
                 },
                 "Component_[14503148882391113363]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14503148882391113363,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Computer_Desk_B075ZBVZST/computer_desk.prefab
+++ b/Gems/ArchVis/Assets/Props/Computer_Desk_B075ZBVZST/computer_desk.prefab
@@ -142,7 +142,7 @@
                     "Id": 5404398586167952305
                 },
                 "Component_[549566275919980709]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 549566275919980709,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Decor_Bench_B082QD7WY8/decor_bench.prefab
+++ b/Gems/ArchVis/Assets/Props/Decor_Bench_B082QD7WY8/decor_bench.prefab
@@ -60,7 +60,7 @@
                     "Id": 13905792950461768599
                 },
                 "Component_[14376407054765774658]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14376407054765774658,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Dinner_Table_B075YP4WYT/dinner_table.prefab
+++ b/Gems/ArchVis/Assets/Props/Dinner_Table_B075YP4WYT/dinner_table.prefab
@@ -150,7 +150,7 @@
                     "Id": 6842166626713226172
                 },
                 "Component_[7149451247539743307]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7149451247539743307,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Dinner_Table_Ceiling_Light/Dinner_Table_Ceiling_Light.prefab
+++ b/Gems/ArchVis/Assets/Props/Dinner_Table_Ceiling_Light/Dinner_Table_Ceiling_Light.prefab
@@ -60,7 +60,7 @@
                     "Id": 12378120647433380967
                 },
                 "Component_[1349120696000774594]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1349120696000774594,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Dinner_Table_Floor_Rug/dinner_table_floor_rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Dinner_Table_Floor_Rug/dinner_table_floor_rug.prefab
@@ -64,7 +64,7 @@
                     "Id": 1258031797052467739
                 },
                 "Component_[12765071306608823372]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12765071306608823372,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/End_Table_B072ZLCB32/end_table.prefab
+++ b/Gems/ArchVis/Assets/Props/End_Table_B072ZLCB32/end_table.prefab
@@ -77,7 +77,7 @@
                     ]
                 },
                 "Component_[17133388636626932378]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17133388636626932378,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Floor_Rug_B0732L974X/rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Floor_Rug_B0732L974X/rug.prefab
@@ -68,7 +68,7 @@
                     "Id": 11872640725570577469
                 },
                 "Component_[12384181215514172824]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12384181215514172824,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Floor_Rug_B0735THVQH/rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Floor_Rug_B0735THVQH/rug.prefab
@@ -154,7 +154,7 @@
                     ]
                 },
                 "Component_[9728572962386384451]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9728572962386384451,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Floor_Rug_B07B4YQGFJ/rug.prefab
+++ b/Gems/ArchVis/Assets/Props/Floor_Rug_B07B4YQGFJ/rug.prefab
@@ -150,7 +150,7 @@
                     }
                 },
                 "Component_[7640891002383393583]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7640891002383393583,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Cook_Book/kitchen_cookbook.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Cook_Book/kitchen_cookbook.prefab
@@ -150,7 +150,7 @@
                     ]
                 },
                 "Component_[18289645534834094934]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 18289645534834094934,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Cutting_Boards/Kitchen_Cutting_Boards.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Cutting_Boards/Kitchen_Cutting_Boards.prefab
@@ -76,7 +76,7 @@
                     "Id": 14898676837601160134
                 },
                 "Component_[167628118935154807]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 167628118935154807,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Knives/Kitchen_Knives.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Knives/Kitchen_Knives.prefab
@@ -101,7 +101,7 @@
                     "Id": 17027217870028804263
                 },
                 "Component_[17716965496971507354]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17716965496971507354,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Oven/kitchen_oven.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Oven/kitchen_oven.prefab
@@ -142,7 +142,7 @@
                     "Id": 6008895314946518116
                 },
                 "Component_[6240048751332204635]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6240048751332204635,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Refrigerator_MOD000016/refrigerator.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Refrigerator_MOD000016/refrigerator.prefab
@@ -64,7 +64,7 @@
                     "Id": 11755868307902649292
                 },
                 "Component_[15809170977647956888]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15809170977647956888,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Spice_Jars/kitchen_spice_jars.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Spice_Jars/kitchen_spice_jars.prefab
@@ -126,7 +126,7 @@
                     }
                 },
                 "Component_[1896423964440584177]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1896423964440584177,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Kitchen_Utensils/kitchen_utensils.prefab
+++ b/Gems/ArchVis/Assets/Props/Kitchen_Utensils/kitchen_utensils.prefab
@@ -127,7 +127,7 @@
                     ]
                 },
                 "Component_[4362766204661301864]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4362766204661301864,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Media_Cabinet_B07QB8DQ45/media_cabinet.prefab
+++ b/Gems/ArchVis/Assets/Props/Media_Cabinet_B07QB8DQ45/media_cabinet.prefab
@@ -88,7 +88,7 @@
                     "Id": 2236219497289017892
                 },
                 "Component_[2447487333919550334]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2447487333919550334,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Night_Stand_Lamp_B07374SBFM/night_stand_lamp.prefab
+++ b/Gems/ArchVis/Assets/Props/Night_Stand_Lamp_B07374SBFM/night_stand_lamp.prefab
@@ -73,7 +73,7 @@
                     "Id": 264080195943988153
                 },
                 "Component_[3209123840354871791]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3209123840354871791,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Office_Desk_Chair_B082BLFMRC/office_desk_chair.prefab
+++ b/Gems/ArchVis/Assets/Props/Office_Desk_Chair_B082BLFMRC/office_desk_chair.prefab
@@ -96,7 +96,7 @@
                     "Id": 1524931509187334113
                 },
                 "Component_[15639442239210968572]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15639442239210968572,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Office_Desk_Lamp_B07B4YHYQV/office_desk_lamp.prefab
+++ b/Gems/ArchVis/Assets/Props/Office_Desk_Lamp_B07B4YHYQV/office_desk_lamp.prefab
@@ -56,7 +56,7 @@
                     "Id": 11713920357012905635
                 },
                 "Component_[12757208755810017111]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12757208755810017111,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_B075HR7LHQ/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_B075HR7LHQ/potted_plant.prefab
@@ -127,7 +127,7 @@
                     }
                 },
                 "Component_[12264693579384619534]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12264693579384619534,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000002/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000002/potted_plant.prefab
@@ -97,7 +97,7 @@
                     "Id": 11664106037724625920
                 },
                 "Component_[12282705548812581643]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12282705548812581643,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000045/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000045/potted_plant.prefab
@@ -137,7 +137,7 @@
                     "Id": 4748929468013442416
                 },
                 "Component_[5436624600400660822]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5436624600400660822,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000054/potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Potted_Plant_TRBP000054/potted_plant.prefab
@@ -52,7 +52,7 @@
             "Name": "potted_plant",
             "Components": {
                 "Component_[1104764010385244140]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1104764010385244140,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Sectional_Sofa_B07QDL46GB/sectional_sofa.prefab
+++ b/Gems/ArchVis/Assets/Props/Sectional_Sofa_B07QDL46GB/sectional_sofa.prefab
@@ -87,7 +87,7 @@
                     "Id": 17405367311171993486
                 },
                 "Component_[18098730244130404488]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 18098730244130404488,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Single_Bed_Frame_B0856FL9HR/single_bed_frame.prefab
+++ b/Gems/ArchVis/Assets/Props/Single_Bed_Frame_B0856FL9HR/single_bed_frame.prefab
@@ -197,7 +197,7 @@
                     "Id": 18322450601296185927
                 },
                 "Component_[4939001040384211321]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4939001040384211321,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Stack_Books_B07374SBFM/stack_books.prefab
+++ b/Gems/ArchVis/Assets/Props/Stack_Books_B07374SBFM/stack_books.prefab
@@ -159,7 +159,7 @@
                     "Id": 16186312037769869476
                 },
                 "Component_[17169885993470343239]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17169885993470343239,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Stack_Magazines/Stack_Magazines.prefab
+++ b/Gems/ArchVis/Assets/Props/Stack_Magazines/Stack_Magazines.prefab
@@ -61,7 +61,7 @@
                     "Id": 11837171408357876688
                 },
                 "Component_[12980665234040873846]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12980665234040873846,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Sunglasses_TRB000046/sunglasses.prefab
+++ b/Gems/ArchVis/Assets/Props/Sunglasses_TRB000046/sunglasses.prefab
@@ -167,7 +167,7 @@
                     "Id": 5430381958332590264
                 },
                 "Component_[6136831406637616568]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6136831406637616568,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/TV_Audio_B082L6KJ2J/tv_audio.prefab
+++ b/Gems/ArchVis/Assets/Props/TV_Audio_B082L6KJ2J/tv_audio.prefab
@@ -163,7 +163,7 @@
                     "Id": 8971163595971639796
                 },
                 "Component_[9394952916952932761]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9394952916952932761,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Table_Chair_B075Z8M22B/table_chair.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Chair_B075Z8M22B/table_chair.prefab
@@ -96,7 +96,7 @@
                     "Id": 13175644011407185703
                 },
                 "Component_[15535069788858427079]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15535069788858427079,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Table_Lamp_B07HKF28CS/table_lamp.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Lamp_B07HKF28CS/table_lamp.prefab
@@ -179,7 +179,7 @@
                     "Id": 3801834752541642727
                 },
                 "Component_[8955785890418585536]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8955785890418585536,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000041/table_potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000041/table_potted_plant.prefab
@@ -89,7 +89,7 @@
                     }
                 },
                 "Component_[6309917713295944295]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6309917713295944295,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000056/table_potted_plant.prefab
+++ b/Gems/ArchVis/Assets/Props/Table_Potted_Plant_TRB000056/table_potted_plant.prefab
@@ -125,7 +125,7 @@
                     }
                 },
                 "Component_[14695071295107025390]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14695071295107025390,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Wall_Art_Two_Set/wall_art_two_set.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Art_Two_Set/wall_art_two_set.prefab
@@ -100,7 +100,7 @@
                     "Id": 14935419640938699758
                 },
                 "Component_[1521301945076782066]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1521301945076782066,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Wall_Clock/Wall_Clock.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Clock/Wall_Clock.prefab
@@ -84,7 +84,7 @@
                     "Id": 15919337670898642848
                 },
                 "Component_[15968303691183849831]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15968303691183849831,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Wall_Painting/Wall_Painting.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Painting/Wall_Painting.prefab
@@ -60,7 +60,7 @@
                     "Id": 11835762462359242578
                 },
                 "Component_[11885409761003560783]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11885409761003560783,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Wall_Painting_Collection_Three/wall_painting_collection_three.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Painting_Collection_Three/wall_painting_collection_three.prefab
@@ -173,7 +173,7 @@
                     }
                 },
                 "Component_[8743155322547890019]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8743155322547890019,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Props/Wall_Print/Wall_Print.prefab
+++ b/Gems/ArchVis/Assets/Props/Wall_Print/Wall_Print.prefab
@@ -81,7 +81,7 @@
                     "Id": 13447601309243456577
                 },
                 "Component_[15026422971092846704]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15026422971092846704,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Gems/ArchVis/Assets/Rooms/Interior_03/interior_03.prefab
+++ b/Gems/ArchVis/Assets/Rooms/Interior_03/interior_03.prefab
@@ -416,7 +416,7 @@
                     }
                 },
                 "Component_[16690343428122660713]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16690343428122660713,
                     "ColliderConfiguration": {
                         "MaterialSlots": {


### PR DESCRIPTION
**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725. 
This is currently as draft to avoid submitting it too early.

**Reviewers**
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

**Testing**
All converted prefabs were processed successfully by the Asset Processor. 
Opened the Loft level in the editor without errors. Manually checked a converted prefab in the level had the correct PhysX Mesh Collider.

Signed-off-by: moraaar <moraaar@amazon.com>